### PR TITLE
Save error object in GCDWebServerErrorResponse

### DIFF
--- a/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/GCDWebServer/Core/GCDWebServerConnection.m
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_END
 
   CFHTTPMessageRef _requestMessage;
   GCDWebServerRequest* _request;
-  GCDWebServerHandler* _handler;
+  GCDWebServerHandler* _handler; // this is where the response is received
   CFHTTPMessageRef _responseMessage;
   GCDWebServerResponse* _response;
   NSInteger _statusCode;
@@ -759,6 +759,7 @@ static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
 
 - (void)processRequest:(GCDWebServerRequest*)request completion:(GCDWebServerCompletionBlock)completion {
   GWS_LOG_DEBUG(@"Connection on socket %i processing request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
+  // `completion` will receive the `GCDWebServerResponse` object
   _handler.asyncProcessBlock(request, [completion copy]);
 }
 

--- a/GCDWebServer/Responses/GCDWebServerErrorResponse.h
+++ b/GCDWebServer/Responses/GCDWebServerErrorResponse.h
@@ -59,6 +59,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
 
 /**
+ *  Initializes an empty response with a specific HTTP status code and error.
+ */
+- (instancetype)initWithStatusCode:(NSInteger)statusCode error:(NSError*)error;
+
+/**
  *  Initializes a client error response with the corresponding HTTP status code.
  */
 - (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);

--- a/GCDWebServer/Responses/GCDWebServerErrorResponse.m
+++ b/GCDWebServer/Responses/GCDWebServerErrorResponse.m
@@ -35,7 +35,9 @@
 #import "GCDWebServerPrivate.h"
 #endif
 
-@implementation GCDWebServerErrorResponse
+@implementation GCDWebServerErrorResponse {
+    NSError *_error;
+}
 
 + (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
   GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
@@ -85,6 +87,13 @@ static inline NSString* _EscapeHTMLString(NSString* string) {
                                               title, title, _EscapeHTMLString(message), error];
   if ((self = [self initWithHTML:html])) {
     self.statusCode = statusCode;
+  }
+  return self;
+}
+
+- (instancetype)initWithStatusCode:(NSInteger)statusCode error:(NSError*)error {
+  if ((self = [super initWithStatusCode:statusCode])) {
+    _error = error;
   }
   return self;
 }


### PR DESCRIPTION
The saved error can provide more detailed context of the error to clients.

This is a corollary to the work on issue https://github.com/readium/swift-toolkit/issues/398.